### PR TITLE
Fix: homepage picture margins

### DIFF
--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -26,6 +26,16 @@
         padding-bottom: 30px;
     }
 }
+// Large screens: make the picture slightly smaller to leave some room between it and
+// the text
+@media (min-width: 992px) {
+    .profile-image img {
+        max-width: 95% !important;
+        display: block;
+        margin-left: auto;
+        margin-right: 0;
+    }
+}
 
 /* ABOUT */
 // Wide screens: decrease unnecessary whitespace around the about section
@@ -52,6 +62,16 @@
 @media (max-width: 991px) {
     .about__profile-picture {
         margin-top: -50px;
+    }
+}
+// Large screens: make the picture slightly smaller to leave some room between it and
+// the text
+@media (min-width: 992px) {
+    .about__profile-picture img {
+        max-width: 96% !important;
+        display: block;
+        margin-left: 0;
+        margin-right: auto;
     }
 }
 


### PR DESCRIPTION
Add padding to the showcase and about pics on larger screens to leave breathing room for the text.