### PR TITLE
Add dedicated about page

### DIFF
--- a/content/about.en.md
+++ b/content/about.en.md
@@ -1,0 +1,18 @@
+---
+slug: 'about'
+date: '2025-01-01T00:00:00+02:00'
+draft: false
+title: 'Who is Cosmo?'
+description: 'Learn more about Cosmo Jenytin'
+type: 'about'
+---
+
+Engineer and data scientist with the ability to understand complex problems and develop practical solutions. In my work – and in life in general – I seek solutions to complex problems and combine different perspectives into practical actions.
+
+Born and raised in Espoo: I have lived my entire life in Espoo. I grew up in Mankkaa in a bilingual family and have now lived in Tapiola for 10 years. I love our city and know its challenges and opportunities.
+
+Active volunteer in organizations: I am involved in a lot. My years in the Aalto University Student Union representative council and Teknologföreningen taught me how to build communities and influence matters effectively. As a bilingual candidate, I also build bridges between different cultures and language groups in everyday life.
+
+Living by my values: Cycling and walking, favoring vegan food, and sustainable consumption are climate actions in my daily life.
+
+As a counterbalance to knowledge work I love woodworking, singing in a choir, and diverse sports such as cycling, badminton, and the gym.

--- a/content/about.fi.md
+++ b/content/about.fi.md
@@ -1,0 +1,18 @@
+---
+slug: 'about'
+date: '2025-01-01T00:00:00+02:00'
+draft: false
+title: 'Kuka Cosmo?'
+description: 'Lisätietoa Cosmo Jenytinistä'
+type: 'about'
+---
+
+Diplomi-insinööri ja datatieteilijä, jolla on kyky ymmärtää monimutkaisia ongelmia ja kehittää toimivia ratkaisuja. Työssäni – ja elämässä muutenkin – etsin ratkaisuja monimutkaisiin ongelmiin ja yhdistän eri näkökulmat käytännön teoiksi.
+
+Paljasjalkainen espoolainen: Olen asunut koko elämäni Espoossa. Kasvoin Mankkaalla kaksikielisessä perheessä ja olen nyt asunut 10 vuotta Tapiolassa. Rakastan kaupunkiamme ja tunnen sen haasteet ja mahdollisuudet.
+
+Järjestöaktiivi: Olen mukana monessa. Vuodet Aalto-yliopiston ylioppilaskunnan edustajistossa ja Teknologföreningenissä opettivat, miten yhteisöjä rakennetaan ja asioihin vaikutetaan tehokkaasti. Kaksikielisenä ehdokkaana rakennan siltoja eri kulttuurien ja kieliryhmien välillä myös arjessa.
+
+Elän arvojeni mukaan: Pyöräily ja kävely, vegaaniruoan suosiminen sekä kestävä kulutus ovat ilmastotekoja arjessani.
+
+Vastapainona tietotyölle rakastan tehdä puutöitä, laulaa kuorossa ja liikkua monipuolisesti pyöräilyn, sulkapallon tai kuntosalin muodossa.

--- a/content/about.sv.md
+++ b/content/about.sv.md
@@ -1,0 +1,18 @@
+---
+slug: 'about'
+date: '2025-01-01T00:00:00+02:00'
+draft: false
+title: 'Vem Cosmo?'
+description: 'Läs mer om Cosmo Jenytin'
+type: 'about'
+---
+
+Diplomingenjör och dataforskare med förmåga att förstå komplexa problem och utveckla fungerande lösningar. I mitt arbete – och i livet överlag – söker jag lösningar på komplexa problem och kombinerar olika perspektiv till praktiska åtgärder.
+
+Livslång Esbobo: Född och uppvuxen i en tvåspråkig familj i Mankans och har bott de senaste 10 åren i Hagalund. Jag älskar staden och känner dess utmaningar och möjligheter.
+
+Finlandssvensk föreningsaktiv: Åren i Aalto-universitetets studentkårs delegation och på Teknologföreningen lärde mig hur man bygger upp gemenskaper och driver frågor på ett effektivt sätt. Som tvåspråkig kandidat förstår jag den särskilda vikten som måste läggas vid att bevara den finlandssvenska servicen och kulturen.
+
+Lever efter mina värderingar: Jag cyklar, promenerar och använder kollektivtrafik aktivt, prioriterar vegansk mat och strävar efter en hållbar konsumtion.
+
+Som motvikt till informationsarbete älskar jag att slöjda, sjunga i Akademen och motionera mångsidigt, vare sig det är cykling, badminton eller gym.

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -30,7 +30,7 @@ about:
   enable: true
   button:
     icon: "icon-user"
-    URL: "#about"
+    URL: "about"
   image:
     x: "images/about/Cosmo-Jenytin-2025-kuntavaalit-ehdokas-vihreät-espoo-inside-medium.jpg"
     _2x: "images/about/Cosmo-Jenytin-2025-kuntavaalit-ehdokas-vihreät-espoo-inside.jpg"

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -1,0 +1,23 @@
+<!-- inject:../components/baseHead/baseHeadStart.html -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {{ partial "head.html" . }} {{ partial "head_custom.html" . }}
+  </head>
+  <body>
+    {{ partial "header.html" . }}
+
+    <section id="about-page" class="section rad-animation-group flex-grow-1">
+      <div class="container">
+        <div class="row flex-column-reverse flex-md-row rad-fade-down">
+          <div class="col-12">
+            {{ .Content | safeHTML }}
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {{ partial "footer.html" . }} {{ partial "base-foot.html" . }}
+  </body>
+</html>
+<!-- endinject -->

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -33,14 +33,13 @@
       <div class="col-12 col-md-6 my-auto my-auto">
         <h2>{{ i18n "about_title" }}</h2>
         {{ i18n "about_content" | safeHTML }}
-        <!-- <a
-          href="{{ .Site.Data.homepage.about.button.URL | absURL }}"
-          target="_blank"
+        <a
+          href="{{ .Site.Data.homepage.about.button.URL | absLangURL }}"
           class="btn btn-primary"
         >
           <i class="{{ .Site.Data.homepage.about.button.icon }}"></i>
           {{ i18n "about_button" }}
-        </a> -->
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- create about pages in English, Finnish and Swedish
- enable About section button and link to new about page
- configure homepage button URL
- add layout for about page

## Testing
- `hugo --minify` *(fails: command not found)*